### PR TITLE
security(edge): catch origin fetch errors; return generic internal_error

### DIFF
--- a/infra/edge/src/index.js
+++ b/infra/edge/src/index.js
@@ -210,7 +210,13 @@ export default {
       body: ['GET', 'HEAD'].includes(method) ? undefined : await request.arrayBuffer(),
     };
 
-    const originResp = await fetch(forwardUrl, init);
+    let originResp;
+    try {
+      originResp = await fetch(forwardUrl, init);
+    } catch (err) {
+      console.error('[edge→origin] fetch failed:', (err && err.message) ? err.message : String(err));
+      return j(false, null, 'internal_error', 502);
+    }
     const status = originResp.status;
     const respHeaders = new Headers(originResp.headers);
     addCors(respHeaders);


### PR DESCRIPTION
- Wrap edge→origin fetch in try/catch
- Log concise error server-side, return { ok:false, error:"internal_error" } with 502
- Prevents stack/exception leakage to clients